### PR TITLE
Fixing issue #320. Added a new ignore button so when you press on it,

### DIFF
--- a/editor/static/js/editor.js
+++ b/editor/static/js/editor.js
@@ -415,9 +415,8 @@ $(document).ready(function() {
         this.setTab = function(id) {
             return function() {
                 var tab = ei.getTab(id);
-
                 ei.currentTab(tab);
-                ei.set_ignored_publishing_criteria(false);
+                ei.ignored_publishing_criteria(false);
             }
         }
 

--- a/editor/static/js/editor.js
+++ b/editor/static/js/editor.js
@@ -406,6 +406,7 @@ $(document).ready(function() {
         this.ability_frameworks = ko.observableArray([]);
 		this.realtags = ko.observableArray([]);
 		this.description = ko.observable('');
+        this.ignored_publishing_criteria = ko.observable(false);
 
 		this.mainTabs = ko.observableArray([]);
 
@@ -416,6 +417,7 @@ $(document).ready(function() {
                 var tab = ei.getTab(id);
 
                 ei.currentTab(tab);
+                ei.set_ignored_publishing_criteria(false);
             }
         }
 
@@ -623,8 +625,12 @@ $(document).ready(function() {
             },this);
 
             this.canPublish = ko.computed(function() {
-                return !this.published() && this.all_sections_completed();
+                return !this.published() && (this.all_sections_completed() || this.ignored_publishing_criteria());
             },this);
+        },
+
+        set_ignored_publishing_criteria: function() {
+                this.ignored_publishing_criteria(true);
         },
 
         init_output: function() {

--- a/editor/templates/editoritem/edit.html
+++ b/editor/templates/editoritem/edit.html
@@ -348,7 +348,7 @@
                                     </ul>
                                 </li>
                             </ul>
-                            <button id="ignore" class="btn btn-danger" data-bind="visible: !all_sections_completed() && !published(), click: set_ignored_publishing_criteria">
+                            <button type="button" class="btn btn-danger" data-bind="click: set_ignored_publishing_criteria, visible: !published() && !all_sections_completed()">
                                  Ignore these tasks and publish
                             </button>
                         </div>

--- a/editor/templates/editoritem/edit.html
+++ b/editor/templates/editoritem/edit.html
@@ -348,6 +348,9 @@
                                     </ul>
                                 </li>
                             </ul>
+                            <button id="ignore" class="btn btn-danger" data-bind="visible: !all_sections_completed() && !published(), click: set_ignored_publishing_criteria">
+                                 Ignore these tasks and publish
+                            </button>
                         </div>
                     </div>
                     <div class="panel panel-warning" data-bind="visible: canPublish">


### PR DESCRIPTION
the Publish block with the publish button will appear. However, it only
works the first time; once you set the flag to true, it won't change
even if we go to different tabs. If you go back and edit the Settings and then come back to the Access page, the Publish block will still be underneath the
Ignore button, but I don't think it's supposed to be like that.