### PR TITLE
Add more variable name validity checks

### DIFF
--- a/editor/static/js/question/edit.js
+++ b/editor/static/js/question/edit.js
@@ -1249,11 +1249,11 @@ $(document).ready(function() {
                 return 'This variable name is reserved.';
             }
 
-            var nameTok = Numbas.jme.tokenise(name);
-            if(nameTok.length != 1){
+            var tokens = Numbas.jme.tokenise(name);
+            if(tokens.length != 1) {
                 return 'This variable name is invalid.';
             }
-            if(nameTok[0].type != 'name') {
+            if(tokens[0].type != 'name') {
                 return 'This variable name is reserved.';
             }
 


### PR DESCRIPTION
Checks the variable name is valid by tokenising the candidate name
and checking that the result is a single token of type 'name'.

Also checks the name is not already a jme builtin variable.

Fixes #406.