### PR TITLE
Fixed broken links in mac and windows installation docs

### DIFF
--- a/mac-local.html
+++ b/mac-local.html
@@ -12,7 +12,7 @@
 
 		<p>
 			These are outline instructions on setting up the Numbas editor on a Mac, for personal use.
-            For instances where multiple users need access to the editor, we recommend following the <a href="ubuntu.html">Ubuntu</a> installation instructions.
+            For instances where multiple users need access to the editor, we recommend following the <a href="ubuntu-web.html">Ubuntu</a> installation instructions.
         </p>
 
         <p>

--- a/windows-local.html
+++ b/windows-local.html
@@ -13,7 +13,7 @@
 
 		<p>
 			These are outline instructions on setting up the Numbas editor on a PC running Windows, for personal use.
-            For instances where multiple users need access to the editor, we recommend following the <a href="ubuntu.html">Ubuntu</a> installation instructions.
+            For instances where multiple users need access to the editor, we recommend following the <a href="ubuntu-web.html">Ubuntu</a> installation instructions.
         </p>
 
         <p>


### PR DESCRIPTION
Couple of links to ubuntu installation page from windows and mac installation pages were broken