### PR TITLE
Fixes issue 505

### DIFF
--- a/editor/templates/question/part_types/numberentry.html
+++ b/editor/templates/question/part_types/numberentry.html
@@ -26,8 +26,10 @@
         {% booleanproperty 'allowFractions' 'Allow the student to enter a fraction?' help_url='question/parts/numberentry.html#term-allow-the-student-to-enter-a-fraction' %}
     </div>
     <div data-bind="fadeVisible: allowFractions">
+        <div data-bind="fadeVisible: fractionPossible">
         {% booleanproperty 'mustBeReduced' 'Must the fraction be reduced?' help_url='question/parts/numberentry.html#term-must-the-fraction-be-reduced' %}
         {% booleanproperty 'showFractionHint' 'Show fraction input hint?' help_url='question/parts/numberentry.html#term-show-fraction-input-hint' %}
+        </div>
         <div data-bind="fadeVisible: mustBeReduced">
             {% percentproperty 'mustBeReducedPC' 'Partial credit for unreduced fraction' %}
         </div>


### PR DESCRIPTION
Buttons for "must the fraction be reduced?" and "show fraction input hint?" no longer appear when precision type is changed to decimal or significant figures if the allow fraction option had previously been checked.