### PR TITLE
Fixed broken extension help link

### DIFF
--- a/accounts/templates/profile/extensions.html
+++ b/accounts/templates/profile/extensions.html
@@ -62,6 +62,6 @@
 {% endif %}
 {% endif %}
 
-<p><a target="numbasquickhelp" href="{{HELP_URL}}extensions.html"><span class="glyphicon glyphicon-question-sign"></span> Help with extensions</a></p>
+<p><a target="numbasquickhelp" href="{{HELP_URL}}extensions/"><span class="glyphicon glyphicon-question-sign"></span> Help with extensions</a></p>
 
 {% endblock profile_content %}


### PR DESCRIPTION
Closes #533.

Changed broken link in `accounts/templates/profile/extensions.html` which redirected to https://docs.numbas.org.uk/en/latest/extensions.html instead of https://docs.numbas.org.uk/en/latest/extensions/.

_This PR was made as a part of Hacktoberfest 2020._
