### PR TITLE
Issue 506: Some options for what's shown on the results page

### DIFF
--- a/editor/static/js/exam/edit.js
+++ b/editor/static/js/exam/edit.js
@@ -154,6 +154,8 @@ $(document).ready(function() {
         this.reviewshowfeedback = ko.observable(true);
         this.reviewshowexpectedanswer = ko.observable(true);
         this.reviewshowadvice = ko.observable(true);
+        this.resultsshowquestions = ko.observable(true);
+        this.resultsshowadvice = ko.observable(true);
 
         this.intro = ko.observable('');
         this.end_message = ko.observable('');
@@ -466,6 +468,10 @@ $(document).ready(function() {
                     reviewshowfeedback: this.reviewshowfeedback(),
                     reviewshowexpectedanswer: this.reviewshowexpectedanswer(),
                     reviewshowadvice: this.reviewshowadvice(),
+                    results_options : {
+                        resultsshowquestions : this.resultsshowquestions(),
+                        resultsshowadvice : this.resultsshowadvice(),
+                    },
                     feedbackmessages: this.feedbackMessages().map(function(f){return f.toJSON()})
                 },
                 diagnostic: {
@@ -515,6 +521,9 @@ $(document).ready(function() {
 
             if('feedback' in content) {
                 tryLoad(content.feedback,['showactualmark','showtotalmark','showanswerstate','allowrevealanswer','advicethreshold','intro','end_message','reviewshowscore','reviewshowfeedback','reviewshowexpectedanswer','reviewshowadvice'],this);
+                if ('results_options' in content.feedback){
+                    tryLoad(content.feedback.results_options,['resultsshowquestions','resultsshowadvice'],this);
+                }
                 if('feedbackmessages' in content.feedback) {
                     this.feedbackMessages(content.feedback.feedbackmessages.map(function(d){var f = new FeedbackMessage(); f.load(d); return f}));
                 }

--- a/editor/templates/exam/tabs/feedback.html
+++ b/editor/templates/exam/tabs/feedback.html
@@ -47,6 +47,8 @@
         {% booleanproperty 'reviewshowfeedback' 'Show part feedback messages in review mode?' help_url='exam/reference.html#term-Show-part-feedback-messages-in-review-mode' %}
         {% booleanproperty 'reviewshowexpectedanswer' 'Show expected answers in review mode?' help_url='exam/reference.html#term-Show-expected-answers-in-review-mode' %}
         {% booleanproperty 'reviewshowadvice' 'Show question advice in review mode?' help_url='exam/reference.html#term-Show-question-advice-in-review-mode' %}
+        {% booleanproperty 'resultsshowquestions' 'Show questions in printed results summary?' help_url='exam/reference.html#term-Show-questions-in-printed-results-summary' %}
+        {% booleanproperty 'resultsshowadvice' 'Show advice in printed results summary?' help_url='exam/reference.html#term-Show-advice-in-printed-results-summary' %}
 
         <h4>
             Feedback messages


### PR DESCRIPTION
**Background**
Editor changes to implement option not to show the questions and advice on the printed version of the results page.

**Changes**
- Add `resultsshowquestions ` and `resultsshowadvice` properties to `Exam`
- Add  support for a `results_options` object in exam JSON, to both `load` and `toJSON` functions
- Update feedback.html to allow selection of each option 
- Add placeholder links to docs

**Discussion**
- If show questions is unselected, then the show advice selection is redundant (since there will be no questions for which to show advice). Should the user be made aware of this, e.g. by disabling the show advice checkbox?
- Documentation TBD