### PR TITLE
fix duplicate name error warning logic

### DIFF
--- a/editor/static/js/question/edit.js
+++ b/editor/static/js/question/edit.js
@@ -771,20 +771,29 @@ $(document).ready(function() {
 
             //  Finally, mark duplicate names
             names.sort(Numbas.util.sortBy('name'));
+            var groupArray = [];
             function handle_group(group) {
-                group.forEach(function(n) {
-                    //n.v.duplicateNameError(group.length > 1 ? n.name : null);
+                group.forEach(function (n) {
+                    n.v.duplicateNameError(null);
                 });
+                groupArray.push(group);
             }
 
             var start = 0;
-            names.forEach(function(n,i) {
-                if(n.name!=names[start].name) {
-                    handle_group(names.slice(start,i));
+            names.forEach(function (n, i) {
+                if (n.name != names[start].name) {
+                    handle_group(names.slice(start, i));
                     start = i;
                 }
             });
             handle_group(names.slice(start));
+            // Triggers duplicateNameError observable for groups with duplicates
+            groupArray.forEach(function (group) {
+                var groupVariable = group[0];
+                if (group.length > 1 && groupVariable.name != "") {
+                    groupVariable.v.duplicateNameError(groupVariable.name);
+                }
+            })
         },this).extend({rateLimit: 2000});
 
         /** Create an instance of this question as a Numbas.Question object.
@@ -1963,15 +1972,11 @@ $(document).ready(function() {
 
         var nameError = ko.pureComputed(function() {
             var duplicateNameError = v.duplicateNameError();
-            var nameErrDuplicates = {} // tracks duplicate names using an object
-            var name_errors = names().map(function(nd) {
-                var name = nd.name.toLowerCase();
-                if(nameErrDuplicates[name] && name!=='') {
-                    return 'There\'s another variable or constant with the name '+name+'.';
-                } else {
-                    nameErrDuplicates[name] = true
+            var name_errors = names().map(function (nd) {
+                var name = nd.name;
+                if (name.toLowerCase() == duplicateNameError) {
+                    return 'There\'s another variable or constant with the name ' + name + '.';
                 }
-                console.log("NameErr Map: ",nameErrDuplicates)
                 if(name=='') {
                     return '';
                 }

--- a/editor/static/js/question/edit.js
+++ b/editor/static/js/question/edit.js
@@ -773,7 +773,7 @@ $(document).ready(function() {
             names.sort(Numbas.util.sortBy('name'));
             function handle_group(group) {
                 group.forEach(function(n) {
-                    n.v.duplicateNameError(group.length > 1 ? n.name : null);
+                    //n.v.duplicateNameError(group.length > 1 ? n.name : null);
                 });
             }
 
@@ -1963,11 +1963,15 @@ $(document).ready(function() {
 
         var nameError = ko.pureComputed(function() {
             var duplicateNameError = v.duplicateNameError();
+            var nameErrDuplicates = {} // tracks duplicate names using an object
             var name_errors = names().map(function(nd) {
-                var name = nd.name;
-                if(name.toLowerCase() == duplicateNameError) {
+                var name = nd.name.toLowerCase();
+                if(nameErrDuplicates[name] && name!=='') {
                     return 'There\'s another variable or constant with the name '+name+'.';
+                } else {
+                    nameErrDuplicates[name] = true
                 }
+                console.log("NameErr Map: ",nameErrDuplicates)
                 if(name=='') {
                     return '';
                 }


### PR DESCRIPTION
The following code fixes the duplicate warning logic. Previously, the duplicate error logic would sort the names of the entries in the names input field, turn them into variable objects, and group them. Each group would be processed by the handle_group function, which would trigger updating the duplicateNameError knock-out observable if there more than 1 object in the group. The issue with this method is if the user inputs `a,b,a` , the `a` group would trigger the duplicateNameError function, but once the `b` group is processed, the duplicateNameError observable updates to `null`.

I used an object to track if there were any duplicates. Each time the user updates input names, a new object is created, and if there are duplicates, it returns the name error message. 
![CleanShot 2024-05-14 at 16 28 07](https://github.com/numbas/editor/assets/36749051/1982d76e-88b2-4f84-87c4-0fbaaee4d6b8)
